### PR TITLE
Replaces Problem JSON with Error JSON

### DIFF
--- a/chapters/data-formats.adoc
+++ b/chapters/data-formats.adoc
@@ -28,7 +28,7 @@ Previously, this guideline allowed the use of custom media types like
 `application/x.zalando.article+json`. This usage is not recommended
 anymore and should be avoided, except where it is necessary for cases of
 <<114,media type versioning>>. Instead, just use the standard media type name
-`application/json` (or `application/problem+json` for <<176>>).
+`application/json`.
 
 Custom media types beginning with `x` bring no advantage compared to the
 standard media type for JSON, and make automated processing more difficult.

--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -295,122 +295,91 @@ Whenever the processing of a request fails partially or completely, an
 endpoint must return a suitable HTTP status code together with an Error
 JSON Object and the media type `application/json`. The Error JSON must
 be returned whether the failure has been caused by the client or the server
-(i.e. for 4xx as well as for 5xx error codes). The JSON schema definition
+(i.e. for 4xx as well as for 5xx error codes). The OpenAPI schema definition
 of the Error JSON object is as follows:
 
-[source,json]
-----
-{
-  "definitions": {},
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "title": "Error JSON",
-  "required": [
-    "code",
-    "type",
-    "status",
-    "message",
-    "traceId"
-  ],
-  "properties": {
-    "code": {
-      "type": "string",
-      "description": "A textual identifier of the error.",
-      "examples": [
-        "INVALID_INVOICE_AMOUNT"
-      ]
-    },
-    "type": {
-      "type": "string",
-      "x-extensible-enum": [
-        "BAD_REQUEST",
-        "UNAUTHORIZED",
-        "FORBIDDEN",
-        "NOT_FOUND",
-        "CONFLICT",
-        "INTERNAL",
-        "METHOD_NOT_ALLOWED"
-      ],
-      "description": "A textual identifier of the error category.",
-      "examples": [
-        "BAD_REQUEST"
-      ]
-    },
-    "status": {
-      "type": "integer",
-      "description": "The HTTP status code.",
-      "examples": [
-        404
-      ]
-    },
-    "message": {
-      "type": "string",
-      "description": "The error message.",
-      "examples": [
-        "Invoice amount cannot be negative or zero."
-      ]
-    },
-    "arguments": {
-      "type": "array",
-      "description": "Error arguments for interpolating the localized error message.",
-      "items": {
-        "type": "string",
-        "description": "An error argument for interpolating the localized error message.",
-        "examples": [
-          "100",
-          "50"
-        ]
-      }
-    },
-    "traceId": {
-      "type": "string",
-      "description": "Trace identifier for correlating the error to service interactions.",
-      "examples": [
-        "avfcsdc28374876234628"
-      ]
-    },
-    "errorDetails": {
-      "type": "array",
-      "description": "Error details.",
-      "items": {
-        "type": "object",
-        "description": "An error detail.",
-        "required": [
-          "code",
-          "message"
-        ],
-        "properties": {
-          "code": {
-            "type": "string",
-            "description": "A textual identifier of the error.",
-            "examples": [
-              "INVALID_INVOICE_AMOUNT"
-            ]
-          },
-          "message": {
-            "type": "string",
-            "description": "The error message.",
-            "examples": [
-              "Invoice amount cannot be negative or zero."
-            ]
-          },
-          "arguments": {
-            "type": "array",
-            "description": "Error arguments for interpolating the localized error message.",
-            "items": {
-              "type": "string",
-              "description": "An error argument for interpolating the localized error message.",
-              "examples": [
-                "100",
-                "50"
-              ]
-            }
-          }
-        }
-      }
-    }
-  }
-}
+[source,yaml]
+---
+Error:
+  type: object
+  required:
+    - code
+    - type
+    - status
+    - message
+    - traceId
+  properties:
+    code:
+      type: string
+      description: A textual identifier of the error.
+      examples:
+        - INVALID_INVOICE_AMOUNT
+    type:
+      type: string
+      x-extensible-enum:
+        - BAD_REQUEST
+        - UNAUTHORIZED
+        - FORBIDDEN
+        - NOT_FOUND
+        - CONFLICT
+        - INTERNAL
+        - METHOD_NOT_ALLOWED
+      description: A textual identifier of the error category.
+      examples:
+        - BAD_REQUEST
+    status:
+      type: integer
+      description: The HTTP status code.
+      examples:
+        - 404
+    message:
+      type: string
+      description: The error message.
+      examples:
+        - Invoice amount cannot be negative or zero.
+    arguments:
+      type: array
+      description: Error arguments for interpolating the localized error message.
+      items:
+        type: string
+        description: An error argument for interpolating the localized error message.
+        examples:
+          - '100'
+          - '50'
+    traceId:
+      type: string
+      description: Trace identifier for correlating the error to service interactions.
+      examples:
+        - avfcsdc28374876234628
+    errorDetails:
+      type: array
+      description: Error details.
+      items:
+        type: object
+        description: An error detail.
+        required:
+          - code
+          - message
+        properties:
+          code:
+            type: string
+            description: A textual identifier of the error.
+            examples:
+              - INVALID_INVOICE_AMOUNT
+          message:
+            type: string
+            description: The error message.
+            examples:
+              - Invoice amount cannot be negative or zero.
+          arguments:
+            type: array
+            description: Error arguments for interpolating the localized error message.
+            items:
+              type: string
+              description: An error argument for interpolating the localized error message.
+              examples:
+                - '100'
+                - '50'
 ----
 
 [#177]

--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -296,7 +296,7 @@ endpoint must return a suitable HTTP status code together with an Error
 JSON Object and the media type `application/json`. The Error JSON must
 be returned whether the failure has been caused by the client or the server
 (i.e. for 4xx as well as for 5xx error codes). The JSON schema definition
-of the Error JSON object can be found here:
+of the Error JSON object is as follows:
 
 [source,json]
 ----
@@ -315,14 +315,14 @@ of the Error JSON object can be found here:
   "properties": {
     "code": {
       "type": "string",
-      "title": "Textual Identifier of Error",
+      "description": "A textual identifier of the error.",
       "examples": [
         "INVALID_INVOICE_AMOUNT"
       ]
     },
     "type": {
       "type": "string",
-      "enum": [
+      "x-extensible-enum": [
         "BAD_REQUEST",
         "UNAUTHORIZED",
         "FORBIDDEN",
@@ -331,31 +331,31 @@ of the Error JSON object can be found here:
         "INTERNAL",
         "METHOD_NOT_ALLOWED"
       ],
-      "title": "Textual Identifier of Error Category",
+      "description": "A textual identifier of the error category.",
       "examples": [
         "BAD_REQUEST"
       ]
     },
     "status": {
       "type": "integer",
-      "title": "HTTP Status Code",
+      "description": "The HTTP status code.",
       "examples": [
         404
       ]
     },
     "message": {
       "type": "string",
-      "title": "Error Message",
+      "description": "The error message.",
       "examples": [
         "Invoice amount cannot be negative or zero."
       ]
     },
     "arguments": {
       "type": "array",
-      "title": "Error Arguments for Interpolation of Localized Error Message",
+      "description": "Error arguments for interpolating the localized error message.",
       "items": {
         "type": "string",
-        "title": "Error Argument for Interpolation of Localized Error Message",
+        "description": "An error argument for interpolating the localized error message.",
         "examples": [
           "100",
           "50"
@@ -364,43 +364,42 @@ of the Error JSON object can be found here:
     },
     "traceId": {
       "type": "string",
-      "title": "Error Correlation ID",
+      "description": "Trace identifier for correlating the error to service interactions.",
       "examples": [
         "avfcsdc28374876234628"
       ]
     },
     "errorDetails": {
       "type": "array",
-      "title": "Error Details",
+      "description": "Error details.",
       "items": {
         "type": "object",
-        "title": "Error Detail",
+        "description": "An error detail.",
         "required": [
           "code",
-          "message",
-          "arguments"
+          "message"
         ],
         "properties": {
           "code": {
             "type": "string",
-            "title": "Textual Identifier of Error",
+            "description": "A textual identifier of the error.",
             "examples": [
               "INVALID_INVOICE_AMOUNT"
             ]
           },
           "message": {
             "type": "string",
-            "title": "Error Message",
+            "description": "The error message.",
             "examples": [
               "Invoice amount cannot be negative or zero."
             ]
           },
           "arguments": {
             "type": "array",
-            "title": "Error Arguments for Interpolation of Localized Error Message",
+            "description": "Error arguments for interpolating the localized error message.",
             "items": {
               "type": "string",
-              "title": "Error Argument for Interpolation of Localized Error Message",
+              "description": "An error argument for interpolating the localized error message.",
               "examples": [
                 "100",
                 "50"

--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -12,8 +12,7 @@ define how an API is used correctly.
 Therefore, you must define **all** success and service specific error
 responses in your API specification. Both are part of the interface definition
 and provide important information for service clients to handle standard as
-well as exceptional situations. 
-
+well as exceptional situations.
 
 **Hint:** In most cases it is not useful to document all technical errors,
 especially if they are not under control of the service provider. Thus unless
@@ -26,11 +25,10 @@ response specifications can be combined using the following pattern:
 responses:
   ...
   default:
-    description: error occurred - see status code and problem object for more information.
+    description: error occurred - see status code and error object for more information.
     content:
-      "application/problem+json":
-        schema:
-          $ref: 'https://zalando.github.io/problem/schema.yaml#/Problem'
+      "application/json":
+        schema: see #176
 ----
 
 API designers should also think about a **troubleshooting board** as part of
@@ -291,41 +289,130 @@ number of requests made within a given window for each named entity.
 
 
 [#176]
-== {MUST} Use Problem JSON
+== {MUST} Use Error JSON
 
-{RFC-7807}[RFC 7807] defines a Problem JSON object and  the media type
-`application/problem+json`. Operations should return it (together with a
-suitable status code) when any problem occurred during processing and you can
-give more details than the status code itself can supply, whether it be caused
-by the client or the server (i.e. both for {4xx} or {5xx} error codes).
+Whenever the processing of a request fails partially or completely, an
+endpoint must return a suitable HTTP status code together with an Error
+JSON Object and the media type `application/json`. The Error JSON must
+be returned whether the failure has been caused by the client or the server
+(i.e. for 4xx as well as for 5xx error codes). The JSON schema definition
+of the Error JSON object can be found here:
 
-The Open API schema definition of the Problem JSON object can be found
-https://zalando.github.io/problem/schema.yaml[on github]. You can
-reference it by using:
-
-[source,yaml]
+[source,json]
 ----
-responses:
-  503:
-    description: Service Unavailable
-    content:
-      "application/problem+json":
-        schema:
-          $ref: 'https://zalando.github.io/problem/schema.yaml#/Problem'
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Error JSON",
+  "required": [
+    "code",
+    "type",
+    "status",
+    "message",
+    "traceId"
+  ],
+  "properties": {
+    "code": {
+      "type": "string",
+      "title": "Textual Identifier of Error",
+      "examples": [
+        "INVALID_INVOICE_AMOUNT"
+      ]
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "BAD_REQUEST",
+        "UNAUTHORIZED",
+        "FORBIDDEN",
+        "NOT_FOUND",
+        "CONFLICT",
+        "INTERNAL",
+        "METHOD_NOT_ALLOWED"
+      ],
+      "title": "Textual Identifier of Error Category",
+      "examples": [
+        "BAD_REQUEST"
+      ]
+    },
+    "status": {
+      "type": "integer",
+      "title": "HTTP Status Code",
+      "examples": [
+        404
+      ]
+    },
+    "message": {
+      "type": "string",
+      "title": "Error Message",
+      "examples": [
+        "Invoice amount cannot be negative or zero."
+      ]
+    },
+    "arguments": {
+      "type": "array",
+      "title": "Error Arguments for Interpolation of Localized Error Message",
+      "items": {
+        "type": "string",
+        "title": "Error Argument for Interpolation of Localized Error Message",
+        "examples": [
+          "100",
+          "50"
+        ]
+      }
+    },
+    "traceId": {
+      "type": "string",
+      "title": "Error Correlation ID",
+      "examples": [
+        "avfcsdc28374876234628"
+      ]
+    },
+    "errorDetails": {
+      "type": "array",
+      "title": "Error Details",
+      "items": {
+        "type": "object",
+        "title": "Error Detail",
+        "required": [
+          "code",
+          "message",
+          "arguments"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Textual Identifier of Error",
+            "examples": [
+              "INVALID_INVOICE_AMOUNT"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "title": "Error Message",
+            "examples": [
+              "Invoice amount cannot be negative or zero."
+            ]
+          },
+          "arguments": {
+            "type": "array",
+            "title": "Error Arguments for Interpolation of Localized Error Message",
+            "items": {
+              "type": "string",
+              "title": "Error Argument for Interpolation of Localized Error Message",
+              "examples": [
+                "100",
+                "50"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}
 ----
-
-You may define custom problem types as extension of the Problem JSON object 
-if your API need to return specific additional error detail information.
-
-
-**Hint** for backward compatibility: A previous version of this guideline
-(before the publication of {RFC-7807}[RFC 7807] and the registration of the
-media type) told to return custom variant of the media type
-`application/x.problem+json`. Servers for APIs defined before this change
-should pay attention to the `Accept` header sent by the client and set the
-`Content-Type` header of the problem response correspondingly. Clients of such
-APIs should accept both media types.
-
 
 [#177]
 == {MUST} Do not expose Stack Traces

--- a/chapters/tooling.adoc
+++ b/chapters/tooling.adoc
@@ -34,8 +34,6 @@ http://swagger.io/open-source-integrations/[Community-Driven Language Integratio
 
 These utility libraries support you in implementing various parts of our RESTful API guidelines (sorted alphabetically):
 
-* *https://github.com/zalando/problem[Problem]:*
-  Java library that implements application/problem+json
 * *https://github.com/zalando/problem-spring-web[Problems for Spring Web MVC]:*
   library for handling Problems in Spring Web MVC
 * *https://github.com/zalando/jackson-datatype-money[Jackson Datatype Money]:*

--- a/legacy/common-data-types/CommonDataTypes.html
+++ b/legacy/common-data-types/CommonDataTypes.html
@@ -10,7 +10,7 @@
       target['generic-fields'] = '../index.html#generic-fields';
       target['address-fields'] = '../index.html#address-fields';
       target['must-follow-hypertext-control-conventions'] = '../index.html#175';
-      target['must-use-problem-json'] = '../index.html#176';
+      target['must-use-error-json'] = '../index.html#176';
       target['must-do-not-expose-stack-traces'] = '../index.html#177';
 
       var fragment = window.location.href.split('#')[1];


### PR DESCRIPTION
This PR replaces the Problem JSON specification with the Error JSON format that is already used (see https://fenius.atlassian.net/wiki/spaces/NOVA/pages/638320688/MPDK). It also replaces the media type `application/problem+json` with `application/json`.