### PR TITLE
Adjusted: Proprietary Headers chapter

### DIFF
--- a/chapters/proprietary-headers.adoc
+++ b/chapters/proprietary-headers.adoc
@@ -9,20 +9,20 @@ explicitly visible. Use the parameter definitions of the resource HTTP
 methods.
 
 [#183]
-== {MUST} Use Only the Specified Proprietary Zalando Headers
+== {MUST} Use Only the Specified Proprietary Headers
 
-As a general rule, proprietary HTTP headers should be avoided. Still
+As a general rule, proprietary HTTP headers should be avoided. Still,
 they can be useful in cases where context needs to be passed through
 multiple services in an end-to-end fashion. As such, a valid use-case
 for a proprietary header is providing context information, which is not
 a part of the actual API, but is needed by subsequent communication.
 
 From a conceptual point of view, the semantics and intent of an
-operation should always be expressed by URLs path and query parameters,
+operation should always be expressed by URL's path and query parameters,
 the method, and the content. Headers are more often used to implement
-functions close to the protocol considerations, such as flow control,
+functions close to protocol considerations, such as flow control,
 content negotiation, and authentication. Thus, headers are reserved for
-general context information ({RFC-7231#section-5[RFC 7231]).
+general context information ({RFC-7231}#section-5[RFC 7231]).
 
 `X-` headers were initially reserved for unstandardized parameters, but the
 usage of `X-` headers is deprecated ({RFC-6648}[RFC 6648]). This complicates
@@ -30,10 +30,6 @@ the contract definition between consumer and producer of an API following
 these guidelines, since there is no aligned way of using those headers.
 Because of this, the guidelines restrict which `X-` headers can be used
 and how they are used.
-
-The Internet Engineering Task Force's states in {RFC-6648}[RFC 6648] that
-company specific header' names should incorporate the organization's name.
-We aim for backward compatibility, and therefore keep the `X-` prefix.
 
 The following proprietary headers have been specified by this guideline
 for usage so far. Remember that HTTP header field names are not
@@ -43,50 +39,56 @@ case-sensitive.
 |=======================================================================
 |Header field name |Type |Description |Header field value example
 
-|[[x-flow-id]]{X-Flow-ID}|String|
-For more information see <<233>>.
-|GKY7oDhpSiKY_gAAAABZ_A
+|X-B3-TraceId
+|String
+|Zipkin tracing: trace identifier. For more information see <<233>>.
+|463ac35c9f6413ad
 
-|[[x-tenant-id]]{X-Tenant-ID}|String|
-Identifies the tenant initiated the request
-to the multi tenant Zalando Platform. The {X-Tenant-ID} must be set 
-according to the Business Partner ID extracted from the OAuth token when 
-a request from a Business Partner hits the Zalando Platform. 
-|9f8b3ca3-4be5-436c-a847-9cd55460c495
+|X-B3-SpanId
+|String
+|Zipkin tracing: identifier of current span.
+|a2fb4a1d1a96d312
 
-|[[x-sales-channel]]{X-Sales-Channel}|String|
-Sales channels are owned by retailers and represent a specific consumer segment
-being addressed with a specific product assortment that is offered via CFA
-retailer catalogs to consumers (see
-https://pages.github.bus.zalan.do/core-platform/docs/glossary/glossary.html[platform
-glossary (internal link)])
-|52b96501-0f8d-43e7-82aa-8a96fab134d7
+|X-B3-ParentSpanId
+|String
+|Zipkin tracing: identifier of parent span.
+|0020000000000001
 
-|[[c-frontend-type]]{X-Frontend-Type}|String|
-Consumer facing applications (CFAs) provide business experience to their
-customers via different frontend application types, for instance, mobile app
-or browser. Info should be passed-through as generic aspect -- there are
-diverse concerns, e.g. pushing mobiles with specific coupons, that make use of
-it. Current range is mobile-app, browser, facebook-app, chat-app
-|mobile-app
+|X-B3-Sampled
+|String
+|Zipkin tracing: sampling state.
+|1
 
-|[[x-device-type]]{X-Device-Type}|String|
-There are also use cases for steering customer experience (incl. features and
-content) depending on device type. Via this header info should be passed-through
-as generic aspect. Current range is smartphone, tablet, desktop, other.
-|tablet
+|X-B3-Flags
+|String
+|Zipkin tracing: tracing flags.
+|1
 
-|[[x-device-os]]{X-Device-OS}|String|
-On top of device type above, we even want to differ between device platform,
-e.g. smartphone Android vs. iOS. Via this header info should be passed-through
-as generic aspect. Current range is iOS, Android, Windows, Linux, MacOS.
-|Android
+|X-Api
+|String
+|API through which the request was initiated. Either `BUSINESS` or `PARTNER`.
+|BUSINESS
 
-|[[x-app-domain]]{X-App-Domain}|Integer|
-The app domain (i.e. shop channel context) of the request. Note, app-domain is
-a legacy concept that will be replaced in new platform by combinations of main
-CFA concerns like retailer, sales channel, country
-|16
+|X-Actor
+|String
+|Actor that initiated the request.
+|21
+
+|X-AccountId
+|String
+|Identifier of account in context of which the request is processed.
+|17
+
+|X-BusinessId
+|String
+|Identifier of business in context of which the request is processed.
+|30
+
+|X-PartnerUserId
+|String
+|Identifier of partner user that initiated the request.
+|21
+
 |=======================================================================
 
 *Exception:* The only exception to this guideline are the conventional
@@ -95,7 +97,7 @@ hop-by-hop `X-RateLimit-` headers which can be used as defined in <<153>>.
 [#184]
 == {MUST} Propagate Proprietary Headers
 
-All Zalando's proprietary headers are end-to-end headers.
+All Infinitec's proprietary headers are end-to-end headers.
 footnoteref:[header-types, HTTP/1.1 standard ({RFC-7230}#section-6.1[RFC 7230])
 defines two types of headers: end-to-end and hop-by-hop headers. End-to-end
 headers must be transmitted to the ultimate recipient of a request or response.
@@ -103,13 +105,9 @@ Hop-by-hop headers, on the contrary, are meaningful for a single connection
 only.]
 
 All headers specified above must be propagated to the services down the call
-chain. The header names and values must remain unchanged.
-
-For example, the values of the custom headers like `X-Device-Type` can affect
-the results of queries by using device type information to influence
-recommendation results. Besides, the values of the custom headers can influence
-the results of the queries (e.g. the device type information influences the
-recommendation results).
+chain. The header names must remain unchanged. Values of all headers beside
+`X-B3-SpanId`, `X-B3-ParentSpanId`, `X-B3-Sampled` and `X-B3-Flags` must remain
+unchanged.
 
 Sometimes the value of a proprietary header will be used as part of the entity
 in a subsequent request. In such cases, the proprietary headers must still be
@@ -117,56 +115,24 @@ propagated as headers with the subsequent request, despite the duplication of
 information.
 
 [#233]
-== {MUST} Use `X-Flow-ID`
+== {MUST} Use `X-B3-TraceId`
 
-The *Flow-Id* is a generic parameter to be passed through service APIs and
-events and written into log files and traces. A consequent usage of the
-*Flow-Id* facilitates the tracking of call flows through our system and allows
+The *Trace ID* is a generic parameter to be passed through service APIs
+and written into log files and traces. A consequent usage of the
+*Trace ID* facilitates the tracking of call flows through our system and allows
 the correlation of service activities initiated by a specific call. This is
 extremely helpful for operational troubleshooting and log analysis. Main use
-case of *Flow-Id* is to track service calls of our SaaS fashion commerce
-platform and initiated internal processing flows (executed synchronously via
-APIs or asynchronously via published events).
-
-*Data Definition*
-
-The *Flow-Id* must be passed through:
-
-* RESTful API requests via {X-Flow-ID} proprietary header (see <<184>>)
-* Published events via `flow_id` event field (see <<event-metadata, metadata>>)
-
-It must be an random unique string consisting of maximal 128 chars, restricted
-to the character set `[a-zA-Z0-9/+]` (Base64). 
-
-*Note:* If a legacy subsystem can only process _Flow-Ids_ with a specific
-format or length, it must define this restrictions in its API specification,
-and be generous and remove invalid characters or cut the length to the
-supported limit.
-
-*Hint:* In case distributed tracing is supported by {SRE-Tracing}[OpenTracing
-(internal link)] you should ensure that created _spans_ are tagged using
-`flow_id` — see
-{SRE-Tracing}/blob/master/wg-semantic-conventions/best-practices/flowid.md[How
-to Connect Log Output with OpenTracing Using FlowIDs (internal link)] or
-{SRE-Tracing}/blob/master/wg-semantic-conventions/best-practices.md[Best
-practises (internal link)].
+case of *Trace ID* is to track service calls of our platform and initiated
+internal processing flows.
 
 *Service Guidance*
 
-* Services *must* support _Flow-Id_ as generic input, i.e.
-** RESTful API endpoints *must* support {X-Flow-ID} header in requests
-** Event listeners *must* support the metadata `flow-id` from events.
-
+* RESTful API endpoints *must* support `X-B3-TraceId` header in requests.
 +
-*Note:*  API-Clients *must* provide _Flow-Id_ when calling a service or
-producing events. If no _Flow-Id_ is provided in a request or event, the
-service must create a new _Flow-Id_.
+*Note:*  API clients *must* provide _Trace ID_ when calling a service. If no
+_Trace ID_ is provided in a request, the service must create a new _Trace ID_.
 
-* Services *must* propagate _Flow-Id_, i.e. use _Flow-Id_ received
-with API-Calls or consumed events as...
-** input for all API called and events published during processing
-** data field written for logging and tracing
-
-*Hint:* This rule also applies to application internal interfaces and events
-not published via Nakadi (but e.g. via AWS SQS, Kinesis or service specific
-DB solutions).
+* Services *must* propagate _Trace ID_, i.e. use _Trace ID_ received
+with API calls as:
+** input for all APIs called during processing;
+** `traceId` data field written for logging and tracing.

--- a/index.adoc
+++ b/index.adoc
@@ -38,8 +38,6 @@
 :ISO-639-1: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 :ISO-4217: https://en.wikipedia.org/wiki/ISO_4217
 
-:SRE-Tracing: https://github.bus.zalan.do/SRE/opentracing
-
 // Attribute to improve design of key words in titles.
 :MUST: pass:[<span class="must-keyword"><strong>Must</strong></span>:]
 :SHOULD: pass:[<span class="should-keyword"><strong>Should</strong></span>:]


### PR DESCRIPTION
Adjusted whole section on proprietary headers, including recently added MUST: Use `X-Flow-ID` [233].
Added our B3 tracing headers.
Removed parts about events.