### PR TITLE
More general clean-up

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,14 +15,9 @@ docker pull asciidoctor/docker-asciidoctor
 ./check_rule_ids.sh
 
 docker run -v ${SCRIPT_DIR}:/documents/ asciidoctor/docker-asciidoctor asciidoctor -D /documents/output index.adoc
-docker run -v ${SCRIPT_DIR}:/documents/ asciidoctor/docker-asciidoctor asciidoctor-pdf -D /documents/output index.adoc
-docker run -v ${SCRIPT_DIR}:/documents/ asciidoctor/docker-asciidoctor asciidoctor-epub3 -D /documents/output index.adoc
 
 cp ./LICENSE ${BUILD_DIR}/
 cp -r assets ${BUILD_DIR}/
 cp -r -n legacy/* ${BUILD_DIR}/
 
 ./generate_rules_json.sh
-
-mv ${BUILD_DIR}/index.pdf ${BUILD_DIR}/zalando-guidelines.pdf
-mv ${BUILD_DIR}/index.epub ${BUILD_DIR}/zalando-guidelines.epub

--- a/index.adoc
+++ b/index.adoc
@@ -156,8 +156,6 @@
 
 NOTE: Our Guidelines are an adaptation of the https://github.com/zalando/restful-api-guidelines[Zalando RESTful API and Event Scheme Guidelines]. Their material as well as our adaptation is licensed under link:LICENSE[Creative Commons Attribution 4.0 International]
 
-Other formats: link:zalando-guidelines.pdf[PDF], link:zalando-guidelines.epub[EPUB3]
-
 toc::[]
 
 :sectnums:

--- a/index.adoc
+++ b/index.adoc
@@ -151,9 +151,8 @@
 :RFC-idempotent: pass:[<a href="https://tools.ietf.org/html/rfc7231#section-4.2.2">idempotent</a>]
 :RFC-cacheable: pass:[<a href="https://tools.ietf.org/html/rfc7231#section-4.2.3">cacheable</a>]
 
-
-= Infinitec RESTful API Guidelines
-Infinitec Solutions GmbH
+:imagesdir: https://infinitec.solutions/wp-content/uploads/2019/03/
+= image:infinitec-solutions-logo.png[Infinitec Solutions,150] RESTful API Guidelines
 
 NOTE: Our Guidelines are an adaptation of the https://github.com/zalando/restful-api-guidelines[Zalando RESTful API and Event Scheme Guidelines]. Their material as well as our adaptation is licensed under link:LICENSE[Creative Commons Attribution 4.0 International]
 

--- a/publish_to_S3.sh
+++ b/publish_to_S3.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+aws s3 sync --delete `pwd`/output s3://infinitec-novadev-internal-docs/api-guidelines


### PR DESCRIPTION
This PR does three little things:

1. Adds infinitec logo to title
1. Removes build and link to other output formats: The Zalando documentation always generated PDFs and EPUB along with the HTML output and linked it. For now we don't need it and so it is removed to save build time.
1. Adds script to build and push output to S3