### PR TITLE
Accumulation of smaller changes

### DIFF
--- a/chapters/changelog.adoc
+++ b/chapters/changelog.adoc
@@ -13,7 +13,7 @@ To see a list of all changes, please have a look at the https://github.com/zalan
 [[rule-changes]]
 == Rule Changes
 
-* `2019-01-24:` Improve guidance on caching (<<149>>, <<227>>). 
+* `2019-01-24:` Improve guidance on caching (<<149>>, <<227>>).
 * `2019-01-15:` Improve guidance on idempotency, introduce idempotency-key (<<229>>, <<231>>).
 * `2018-06-11:` Introduced new naming guidelines for host, permission, and event names.
 * `2018-01-10:` Moved meta information related aspects into new chapter <<meta-information>>.

--- a/chapters/common-data-types.adoc
+++ b/chapters/common-data-types.adoc
@@ -86,7 +86,7 @@ Example JSON Schema:
 ----
 treeNode:
   type: object
-  properties: 
+  properties:
     id:
       description: the identifier of this node
       type: string

--- a/chapters/common-headers.adoc
+++ b/chapters/common-headers.adoc
@@ -163,7 +163,7 @@ components:
       type: string
       required: false
       example: W/"xy", "5", "5db68c06-1a68-11e9-8341-68f728c1ba70"
-    
+
   - If-Match:
       description: |
         The RFC7232 If-Match header field in a request requires the server to
@@ -176,7 +176,7 @@ components:
       type: string
       required: false
       example: "5", "7da7a728-f910-11e6-942a-68f728c1ba70"
-    
+
   - If-None-Match:
       description: |
         The RFC7232 If-None-Match header field in a request requires the server
@@ -184,7 +184,7 @@ components:
         entity-tags. If the provided entity-tag is `*`, it is required that the
         resource does not exist at all (see [RFC 7232 Section
         3.2](https://tools.ietf.org/html/rfc7232#section-3.2).
-    
+
       type: string
       required: false
       example: "7da7a728-f910-11e6-942a-68f728c1ba70", *

--- a/chapters/compatibility.adoc
+++ b/chapters/compatibility.adoc
@@ -174,7 +174,7 @@ prevents objects being extended in the future.
 
 Note that this guideline concentrates on default extensibility and does not
 exclude the use of `additionalProperties` with a schema as a value, which might
-be appropriate in some circumstances, e.g. see <<216>>. 
+be appropriate in some circumstances, e.g. see <<216>>.
 
 
 [#112]
@@ -272,10 +272,10 @@ Using header versioning should:
 *Hint:* Until an incompatible change is necessary, it is recommended to stay
 with the standard `application/json` media type.
 
-Further reading: 
+Further reading:
 https://blog.apisyouwonthate.com/api-versioning-has-no-right-way-f3c75457c0b7[API
 Versioning Has No "Right Way"] provides an overview on different versioning
-approaches to handle breaking changes without being opinionated. 
+approaches to handle breaking changes without being opinionated.
 
 
 [#115]

--- a/chapters/data-formats.adoc
+++ b/chapters/data-formats.adoc
@@ -24,7 +24,7 @@ Other media types may be used in following cases:
 [#172]
 == {SHOULD} Prefer standard Media type name `application/json`
 
-Previously, this guideline allowed the use of custom media types like 
+Previously, this guideline allowed the use of custom media types like
 `application/x.zalando.article+json`. This usage is not recommended
 anymore and should be avoided, except where it is necessary for cases of
 <<114,media type versioning>>. Instead, just use the standard media type name
@@ -55,7 +55,7 @@ Use the following standard formats for country, language and currency
 codes:
 
 * {ISO-3166-1-a2}[ISO 3166-1-alpha2 country codes]
-** (It is "GB", not "UK", even though "UK" has seen some use at Zalando)
+** (It is "GB", not "UK")
 * {ISO-639-1}[ISO 639-1 language code]
 ** https://tools.ietf.org/html/bcp47[BCP-47] (based on {ISO-639-1}[ISO 639-1])
    for language variants
@@ -98,7 +98,7 @@ components:
           format: decimal
           example: 99.95
        ...
-    
+
     OrderList:
       type: object
       properties:

--- a/chapters/deprecation.adoc
+++ b/chapters/deprecation.adoc
@@ -1,13 +1,13 @@
 [[deprecation]]
 = Deprecation
 
-Sometimes it is necessary to phase out an API endpoint (or version), for instance, 
-if a field is no longer supported in the result or a whole business functionality 
-behind an endpoint has to be shut down. There are many other reasons as well. 
-As long as these endpoints are still used by consumers these are breaking 
-changes and not allowed. Deprecation rules have to be applied to make sure that 
+Sometimes it is necessary to phase out an API endpoint (or version), for instance,
+if a field is no longer supported in the result or a whole business functionality
+behind an endpoint has to be shut down. There are many other reasons as well.
+As long as these endpoints are still used by consumers these are breaking
+changes and not allowed. Deprecation rules have to be applied to make sure that
 necessary consumer changes are aligned and deprecated endpoints are not used
-before API changes are deployed. 
+before API changes are deployed.
 
 [#185]
 == {MUST} Obtain Approval of Clients

--- a/chapters/design-principles.adoc
+++ b/chapters/design-principles.adoc
@@ -11,23 +11,22 @@ entities exposed as resources that are identified via URIs and can be
 manipulated via standardized CRUD-like methods using different
 representations, and hypermedia. RESTful APIs
 tend to be less use-case specific and comes with less rigid client /
-server coupling and are more suitable for an ecosystem of (core) services 
-providing a platform of APIs to build diverse new business services. 
-We apply the RESTful web service principles to all kind of application 
-(micro-) service components, independently from whether they provide 
-functionality via the internet or intranet. 
+server coupling and are more suitable for an ecosystem of (core) services
+providing a platform of APIs to build diverse new business services.
+We apply the RESTful web service principles to all kind of application
+(micro-) service components, independently from whether they provide
+functionality via the internet or intranet.
 
 * We prefer REST-based APIs with JSON payloads
 * We prefer systems to be truly RESTful
-footnoteref:[fielding-restful,Per definition of R.Fielding REST APIs have to support
-HATEOAS (maturity level 3). Our guidelines do not strongly advocate for
-full REST compliance, but limited hypermedia usage, e.g. for pagination
-(see <<hypermedia>>).
-However, we still use the term "RESTful API", due to the absence
-of an alternative established term and to keep it like the very majority
-of web service industry that also use the term for their REST
-approximations — in fact, in today's industry full HATEOAS compliant
-APIs are a very rare exception.]
+footnoteref:[fielding-restful,Per definition of R.Fielding REST APIs have to
+support HATEOAS (maturity level 3). Our guidelines do not strongly advocate for
+full REST compliance, but limited hypermedia usage, e.g. for pagination (see
+<<hypermedia>>).  However, we still use the term "RESTful API", due to the
+absence of an alternative established term and to keep it like the very
+majority of web service industry that also use the term for their REST
+approximations — in fact, in today's industry full HATEOAS compliant APIs are a
+very rare exception.]
 
 An important principle for API design and usage is Postel's
 Law, aka http://en.wikipedia.org/wiki/Robustness_principle[The
@@ -35,7 +34,8 @@ Robustness Principle] (see also https://tools.ietf.org/html/rfc1122[RFC 1122]):
 
 * Be liberal in what you accept, be conservative in what you send
 
-_Readings:_ Some interesting reads on the RESTful API design style and service architecture:
+_Readings:_ Some interesting reads on the RESTful API design style and service
+architecture:
 
 * Book:
 https://www.amazon.de/Irresistible-APIs-Designing-that-developers/dp/1617292559[Irresistable
@@ -58,10 +58,8 @@ Styles and the Design of Network-Based Software Architectures]
 [[api-as-a-product]]
 == API as a Product
 
-As mentioned above, Zalando is transforming from an online shop into an
-expansive fashion platform comprising a rich set of products following a
-Software as a Platform (SaaP) model for our business partners. As a
-company we want to deliver products to our (internal and external)
+Infinitec offers a platform for banks and other partners to easily integrate
+with. As a company we want to deliver products to our (internal and external)
 customers which can be consumed like a service.
 
 Platform products provide their functionality via (public) APIs; hence,
@@ -76,35 +74,35 @@ make them irresistible for client engineers
 * Actively improve and maintain API consistency over the long term
 * Make use of customer feedback and provide service level support
 
-Embracing 'API as a Product' facilitates a service ecosystem which can 
-be evolved more easily, and used to experiment quickly with new business 
-ideas by recombining core capabilities. 
-It makes the difference between agile, innovative product service 
-business built on a platform of APIs and ordinary enterprise integration business
-where APIs are provided as "appendix" of existing products to support system integration
-and optimised for local server-side realization. 
+Embracing 'API as a Product' facilitates a service ecosystem which can be
+evolved more easily, and used to experiment quickly with new business ideas by
+recombining core capabilities.  It makes the difference between agile,
+innovative product service business built on a platform of APIs and ordinary
+enterprise integration business where APIs are provided as "appendix" of
+existing products to support system integration and optimised for local
+server-side realization.
 
-Understand the concrete use cases of your customers and carefully check 
-the trade-offs of your API design variants with a product mindset. Avoid short-term 
+Understand the concrete use cases of your customers and carefully check the
+trade-offs of your API design variants with a product mindset. Avoid short-term
 implementation optimizations at the expense of unnecessary client side
-obligations, and have a high attention on API quality and client
-developer experience.
+obligations, and have a high attention on API quality and client developer
+experience.
 
-API as a Product is closely related to our <<100,API First principle>>
-(see next chapter) which is more focused on how we engineer high quality APIs.
+API as a Product is closely related to our <<100,API First principle>> (see
+next chapter) which is more focused on how we engineer high quality APIs.
 
 
 
 [[api-first]]
-== API First 
+== API First
 
 API First is one of our
 https://github.com/zalando/engineering-principles[engineering
 and architecture principles]. In a nutshell API First requires two
 aspects:
 
-* define APIs first, before coding its implementation, using a standard specification
-language
+* define APIs first, before coding its implementation, using a standard
+  specification language.
 * get early review feedback from peers and client developers
 
 By defining APIs outside the code, we want to facilitate early review
@@ -127,7 +125,7 @@ of a contract between service provider and client users
 * infrastructure tooling for API discovery, API GUIs, API documents,
 automated quality checks
 
-Elements of API First are also this API Guidelines and a standardized 
+Elements of API First are also this API Guidelines and a standardized
 API review process as to get early review feedback from
 peers and client developers. Peer review is important for us to get high
 quality APIs, to enable architectural and design alignment and to

--- a/chapters/design-principles.adoc
+++ b/chapters/design-principles.adoc
@@ -96,13 +96,11 @@ next chapter) which is more focused on how we engineer high quality APIs.
 [[api-first]]
 == API First
 
-API First is one of our
-https://github.com/zalando/engineering-principles[engineering
-and architecture principles]. In a nutshell API First requires two
-aspects:
+API First is one of our engineering and architecture principles.
+In a nutshell API First requires two aspects:
 
 * define APIs first, before coding its implementation, using a standard
-  specification language.
+  specification language
 * get early review feedback from peers and client developers
 
 By defining APIs outside the code, we want to facilitate early review

--- a/chapters/general-guidelines.adoc
+++ b/chapters/general-guidelines.adoc
@@ -57,7 +57,7 @@ manual typically describes the following API aspects:
 sequence flows
 
 Each API with an external-public, external-partner, company-internal and
-platform-internal audience *must* prodive a user manual. APIs for other
+platform-internal audience *must* provide a user manual. APIs for other
 audiences *should* provide one.
 The user manual must be published online, e.g. via our documentation hosting platform service,
 GHE pages, or specific team web servers. Please do not forget to include a link to the

--- a/chapters/http-requests.adoc
+++ b/chapters/http-requests.adoc
@@ -106,7 +106,7 @@ URL"_.
 
 *Generally:* {POST} should be used for scenarios that cannot be covered by the
 other methods sufficiently. In such cases, make sure to document the fact that
-{POST} is used as a workaround (see {GET-with-Body}). 
+{POST} is used as a workaround (see {GET-with-Body}).
 
 *Note:* Resource IDs with respect to {POST} requests are created and maintained
 by server and returned with response payload.
@@ -293,7 +293,7 @@ following table showing the major properties of each pattern:
 | Applicable with                       | {PATCH} | {POST}  | {POST}/{PATCH}
 | HTTP Standard                         | {YES}   | {NO}    | {NO}
 | Prevents duplicate (zombie) resources | {YES}   | {YES}   | {NO}
-| Prevents concurrent lost updates      | {YES}   | {NO}    | {NO} 
+| Prevents concurrent lost updates      | {YES}   | {NO}    | {NO}
 | Supports safe retries                 | {YES}   | {YES}   | {YES}
 | Supports exact same response          | {NO}    | {NO}    | {YES}
 | Can be inspected (by intermediaries)  | {YES}   | {NO}    | {YES}
@@ -351,8 +351,8 @@ the escaping of special characters and the maximal URL length.
 [#226]
 == {MUST} Document Implicit Filtering
 
-Sometimes certain collection resources or queries will not list all the 
-possible elements they have, but only those for which the current client 
+Sometimes certain collection resources or queries will not list all the
+possible elements they have, but only those for which the current client
 is authorized to access.
 
 Implicit filtering could be done on:

--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -44,7 +44,7 @@ service client and provider performance.
 You must only use standardized HTTP status codes consistently with their
 intended semantics. You must not invent new HTTP status codes.
 
-RFC standards define ~60 different HTTP status codes with specific semantics 
+RFC standards define ~60 different HTTP status codes with specific semantics
 (mainly {RFC-7231}#section-6[RFC7231] and {RFC-6585}[RFC 6585]) — and there
 are upcoming new ones, e.g.
 https://tools.ietf.org/html/draft-tbray-http-legally-restricted-status-05[draft
@@ -214,7 +214,7 @@ should wait by setting the {Retry-After} header.
 [#220]
 == {MUST} Use Most Specific HTTP Status Codes
 
-You must use the most specific HTTP status code when returning information 
+You must use the most specific HTTP status code when returning information
 about your request processing status or error situations.
 
 [#152]

--- a/chapters/introduction.adoc
+++ b/chapters/introduction.adoc
@@ -1,16 +1,11 @@
 [[introduction]]
 = Introduction
 
-Zalando’s software architecture centers around decoupled microservices
-that provide functionality via RESTful APIs with a JSON payload. Small
-engineering teams own, deploy and operate these microservices in their
-AWS (team) accounts. Our APIs most purely express what our systems do,
-and are therefore highly valuable business assets. Designing
-high-quality, long-lasting APIs has become even more critical for us
-since we started developing our new open platform strategy, which
-transforms Zalando from an online shop into an expansive fashion
-platform. Our strategy emphasizes developing lots of public APIs for our
-external business partners to use via third-party applications.
+Infinitect’s software architecture centers around microservices that provide
+functionality via RESTful APIs with a JSON payload.  Our APIs most purely
+express what our systems do, and are therefore highly valuable business assets.
+Our promise is that we and our partners can easily build custom functionality
+on top of our platform.
 
 With this in mind, we’ve adopted "API First" as one of our key
 engineering principles. Microservices development begins with API
@@ -27,7 +22,7 @@ ensure that our APIs:
 * follow a consistent RESTful style and syntax
 * are consistent with other teams’ APIs and our global architecture
 
-Ideally, all Zalando APIs will look like the same author created them.
+Ideally, all Infinitec APIs will look like the same author created them.
 
 [[conventions-used-in-these-guidelines]]
 == Conventions Used in These Guidelines
@@ -38,27 +33,25 @@ The requirement level keywords "MUST", "MUST NOT", "REQUIRED", "SHALL",
 interpreted as described in https://www.ietf.org/rfc/rfc2119.txt[RFC
 2119].
 
-[[zalando-specific-information]]
-== Zalando specific information
+[[application-of-guidelines]]
+== Application of the Guidelines
 
 The purpose of our "RESTful API guidelines" is to define standards to
-successfully establish "consistent API look and feel" quality. The
-https://confluence.zalando.net/display/GUL/API+Guild[API Guild [internal
-link]] drafted and owns this document. Teams are responsible to fulfill
-these guidelines during API development and are encouraged to contribute
-to guideline evolution via pull requests.
+successfully establish "consistent API look and feel" quality. Teams are
+responsible to fulfill these guidelines during API development and are
+encouraged to contribute to guideline evolution via pull requests.
 
-These guidelines will, to some extent, remain work in progress as our
-work evolves, but teams can confidently follow and trust them.
+These guidelines will, to some extent, remain work in progress as our work
+evolves, but teams can confidently follow and trust them.
 
 In case guidelines are changing, following rules apply:
 
-* existing APIs don't have to be changed, but we recommend it
-* clients of existing APIs have to cope with these APIs based on
-outdated rules
+* existing APIs don't have to be changed, but we recommend it clients of
+* existing APIs have to cope with these APIs based on
+  outdated rules
 * new APIs have to respect the current guidelines
 
-Furthermore you should keep in mind that once an API becomes public
-externally available, it has to be re-reviewed and changed according to
-current guidelines - for sake of overall consistency.
+Furthermore you should keep in mind that once an API becomes public externally
+available, it has to be re-reviewed and changed according to current guidelines
+- for sake of overall consistency.
 

--- a/chapters/introduction.adoc
+++ b/chapters/introduction.adoc
@@ -1,7 +1,7 @@
 [[introduction]]
 = Introduction
 
-Infinitect’s software architecture centers around microservices that provide
+Infinitec’s software architecture centers around microservices that provide
 functionality via RESTful APIs with a JSON payload.  Our APIs most purely
 express what our systems do, and are therefore highly valuable business assets.
 Our promise is that we and our partners can easily build custom functionality
@@ -46,8 +46,8 @@ evolves, but teams can confidently follow and trust them.
 
 In case guidelines are changing, following rules apply:
 
-* existing APIs don't have to be changed, but we recommend it clients of
-* existing APIs have to cope with these APIs based on
+* existing APIs don't have to be changed, but we recommend it
+* clients of existing APIs have to cope with these APIs based on
   outdated rules
 * new APIs have to respect the current guidelines
 

--- a/chapters/json-guidelines.adoc
+++ b/chapters/json-guidelines.adoc
@@ -1,10 +1,10 @@
 [[json-guidelines]]
 = JSON Guidelines
 
-These guidelines provides recommendations for defining JSON data at Zalando.
+These guidelines provides recommendations for defining JSON data.
 JSON here refers to {RFC-7159}[RFC 7159] (which updates {RFC-4627}[RFC 4627]),
 the "application/json" media type and custom JSON media types defined for APIs.
-The guidelines clarifies some specific cases to allow Zalando JSON data to have
+The guidelines clarifies some specific cases to allow JSON data to have
 an idiomatic form across teams and services.
 
 The first some of the following guidelines are about property names, the later
@@ -164,7 +164,7 @@ durations).
 == {MAY} Standards could be used for Language, Country and Currency
 
 * {ISO-3166-1-a2}[ISO 3166-1-alpha2 country]
-* (It's "GB", not "UK", even though "UK" has seen some use at Zalando)
+* (It's "GB", not "UK")
 * {ISO-639-1}[ISO 639-1 language code]
 * https://tools.ietf.org/html/bcp47[BCP-47] (based on {ISO-639-1}[ISO 639-1])
   for language variants

--- a/chapters/meta-information.adoc
+++ b/chapters/meta-information.adoc
@@ -123,8 +123,7 @@ groups with clear organisational and legal boundaries:
   of the platform (e.g. OS, Financial Timeline, UAIM, etc.).
 *company-internal*::
   The API consumers with this audience are restricted to applications owned
-  by the business units of the same the company (e.g. Zalando company with
-  Zalando SE, Zalando Payments SE & Co. KG. etc.)
+  by the business units of the same the company.
 *external-partner*::
   The API consumers with this audience are restricted to applications of
   business partners.

--- a/chapters/meta-information.adoc
+++ b/chapters/meta-information.adoc
@@ -123,7 +123,7 @@ groups with clear organisational and legal boundaries:
   of the platform (e.g. OS, Financial Timeline, UAIM, etc.).
 *company-internal*::
   The API consumers with this audience are restricted to applications owned
-  by the business units of the same the company.
+  by the business units of the same company.
 *external-partner*::
   The API consumers with this audience are restricted to applications of
   business partners.

--- a/chapters/naming.adoc
+++ b/chapters/naming.adoc
@@ -62,7 +62,7 @@ public API, and therefore should be made available under the root "/"
 base path.
 
 If the service should also support non-public, internal APIs
-— for specific operational support functions, for example — we encourage 
+— for specific operational support functions, for example — we encourage
 you to maintain two different API specifications and provide
 <<219, API audience>>. For both APIs, you should not use `/api` as base path.
 

--- a/chapters/pagination.adoc
+++ b/chapters/pagination.adoc
@@ -102,12 +102,12 @@ to an article's `authors` like that:
   "index": 0,
   "page_size": 5,
   "items": [
-    {  
+    {
       "href": "https://...",
       "id": "123e4567-e89b-12d3-a456-426655440000",
       "name": "Kent Beck"
     },
-    {  
+    {
       "href": "https://...",
       "id": "987e2343-e89b-12d3-a456-426655440000",
       "name": "Mike Beedle"

--- a/chapters/performance.adoc
+++ b/chapters/performance.adoc
@@ -8,12 +8,10 @@ APIs should support techniques for reducing bandwidth based on client needs.
 This holds for APIs that (might) have high payloads and/or are used in
 high-traffic scenarios like the public Internet and telecommunication networks.
 Typical examples are APIs used by mobile web app clients with (often) less
-bandwidth connectivity. (Zalando is a 'Mobile First' company, so be mindful of
-this point.)
-
+bandwidth connectivity.
 Common techniques include:
 
-* compression of request and response bodies (see <<156>>) 
+* compression of request and response bodies (see <<156>>)
 * querying field filters to retrieve a subset of resource attributes (see
   <<157>> below)
 * {ETag} and {If-Match}/{If-None-Match} headers to avoid re-fetching of
@@ -93,14 +91,14 @@ Content-Type: application/json
 }
 ----
 
-The query `field` value determines the fields returned with the response payload object. 
+The query `field` value determines the fields returned with the response payload object.
 For instance, `(name)` returns `users` root object with only the `name` field,
 and `(name,friends(name))` returns the `name` and the nested `friends`
-object with only its `name` field. 
+object with only its `name` field.
 
-OpenAPI doesn't support you in formally specifying different return object schemes 
+OpenAPI doesn't support you in formally specifying different return object schemes
 depending on a parameter. When you define the field parameter, we recommend to provide
-the following description: `Endpoint supports filtering of return object fields as 
+the following description: `Endpoint supports filtering of return object fields as
 described in [Rule #157](https://opensource.zalando.com/restful-api-guidelines/#157)`
 
 The syntax of the query `field` value is defined by the following
@@ -113,7 +111,7 @@ https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form[BNF] grammar.
 <field_items>       ::= <field> [ "," <field_items> ]
 <field>             ::= <field_name> | <fields_substruct>
 <fields_substruct>  ::= <field_name> <fields_struct>
-<field_name>        ::= <dash_letter_digit> [ <field_name> ] 
+<field_name>        ::= <dash_letter_digit> [ <field_name> ]
 <dash_letter_digit> ::= <dash> | <letter> | <digit>
 <dash>              ::= "-" | "_"
 <letter>            ::= "A" | ... | "Z" | "a" | ... | "z"

--- a/chapters/security.adoc
+++ b/chapters/security.adoc
@@ -28,8 +28,8 @@ Some examples for standard and resource-specific permissions:
 | `business-partner-service` | |`read` | `business-partner-service.read`
 |=======================================================================
 
-After permission names are defined and the permission is declared in the 
-security definition at the top of an API specification, it should be assigned 
+After permission names are defined and the permission is declared in the
+security definition at the top of an API specification, it should be assigned
 to each API operation by specifying a
 {OpenAPI-3-0-2}#security-requirement-object[security
 requirement] like this:
@@ -55,7 +55,7 @@ as OAuth2 default scope.
 paths:
   /public-information:
     get:
-      summary: Provides public information about ... 
+      summary: Provides public information about ...
                Accessible by any user; no permissions needed.
       security:
         - oauth2:


### PR DESCRIPTION
### Changes

* Removes all trailing whitespaces that were quite prevevlant in the original version.
* Removes all references to Zalando. Either simply replaced with Infinitec or additionally re-written slightly to be still meaningful in our context
* Removes 'travis_deploy.sh' as we do not use Travis for CI.

### How to verify
1. check out this branch
2. build the documentation
3. go through and see that there are not mentions of Zalando
4. Look for accidental changes that might have stemmed from removing trailing whitespaces
5. (Extra credit): Verify that there is no mention of Zalando in the text files with `find chapters -name "*.adoc" -print | xargs grep Zalando`