### PR TITLE
Adding CircleCI build to generate the internal docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,44 @@
+version: 2
+jobs:
+  build:
+    docker:
+    - image: asciidoctor/docker-asciidoctor
+    working_directory: ~/repo
+    steps:
+    - checkout
+    - run:
+        name: build adoc
+        command: asciidoctor -D `pwd`/output `pwd`/index.adoc
+    - persist_to_workspace:
+        root: ~/repo
+        paths:
+        - output/*
+
+  upload:
+    docker:
+    - image: garland/aws-cli-docker:1.15.47
+    working_directory: ~/repo
+    steps:
+    - checkout
+    - attach_workspace:
+        at: ~/repo
+    - run:
+        name: upload adoc
+        command: ./publish_to_S3.sh
+
+workflows:
+  version: 2
+  workflow:
+    jobs:
+    - build:
+        filters:
+          branches:
+            only:
+            - master
+    - upload:
+        requires:
+        - build
+        filters:
+          branches:
+            only:
+            - master

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .sass-cache/
 output/
 .project
+.idea/


### PR DESCRIPTION
To review:

There are 2 approaches:
1) check that the scripts being run do what's intended - For that, the way would be running locally the commands in lines 11 and 27 of `.circleci/config.yml` (if one does not want to change the current state of `internal-docs`, the `publish_to_S3.sh` file could be changed to have the `--dry-run` parameter, but this would be a change against the spirit of the PR)
2) check that CircleCI calls the scripts - for this, only committing to this or another branch and pushing would trigger CircleCI, so not sure it falls into the ground rules. FWIW, I did it (by adding this branch into the configuration filter and removing after it - this can be verified in https://circleci.com/gh/infinitecsolutions/restful-api-guidelines/5 and https://circleci.com/gh/infinitecsolutions/restful-api-guidelines/6 )
